### PR TITLE
Fix default argument in Random_Str constructor for macOS compatibility

### DIFF
--- a/src/Random_Str.cpp
+++ b/src/Random_Str.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-Random_Str::Random_Str(unsigned int length = -1):len(length)
+Random_Str::Random_Str(unsigned int length):len(length)
 {
 	mt.seed(rnd());
 	if(length == -1)

--- a/src/Random_Str.hpp
+++ b/src/Random_Str.hpp
@@ -10,7 +10,7 @@ class Random_Str
 {
 public:
 	Random_Str();
-	Random_Str(unsigned int length);
+	Random_Str(unsigned int length = -1);
 	~Random_Str();
 	
 	std::string Create_Str(std::string candidate_chars);


### PR DESCRIPTION
Adjust the constructor of Random_Str to properly handle default arguments, ensuring compatibility with macOS builds.